### PR TITLE
Fix force unwrapping optional error upon first launch

### DIFF
--- a/RxMyCoordinator/SplitViewControllerDelegate.swift
+++ b/RxMyCoordinator/SplitViewControllerDelegate.swift
@@ -17,8 +17,7 @@ class SplitViewControllerDelegate: NSObject, UISplitViewControllerDelegate {
 	func splitViewController(_ splitViewController: UISplitViewController, collapseSecondary secondaryViewController: UIViewController, onto primaryViewController: UIViewController) -> Bool {
 		let tabBar = primaryViewController as! UITabBarController
 		let secondary = secondaryViewController as! UINavigationController
-		let active = tabBar.selectedViewController as! UINavigationController
-		if secondary.children.last?.restorationIdentifier != "placeholder" {
+		if let active = tabBar.selectedViewController as? UINavigationController, secondary.children.last?.restorationIdentifier != "placeholder" {
 			active.viewControllers += secondary.viewControllers
 			active.topViewController!.navigationItem.leftBarButtonItem = nil
 		}


### PR DESCRIPTION
I got this error: 

```
Fatal error: Unexpectedly found nil while unwrapping an Optional value: file /Users/Tieme/Projects/Repos/Coordinators/RxMyCoordinator/RxMyCoordinator/SplitViewControllerDelegate.swift, line 20
2020-01-30 14:24:11.846349+0100 RxMyCoordinator[78904:18299964] Fatal error: Unexpectedly found nil while unwrapping an Optional value: file /Users/Tieme/Projects/Repos/Coordinators/RxMyCoordinator/RxMyCoordinator/SplitViewControllerDelegate.swift, line 20
(lldb) 
```

When running the app the first time, this patch fixes it. 

![image](https://user-images.githubusercontent.com/1330668/73453500-6d72f200-436c-11ea-95c6-03aeadfc50d3.png)

Probably caused because you later added restoration without testing a fresh install. 
